### PR TITLE
Change units and prefixes

### DIFF
--- a/x11-ui.c
+++ b/x11-ui.c
@@ -574,9 +574,8 @@ void xclose(Widget w, XEvent * event, String * params, Cardinal * num)
  * @value: the number that needs a prefix.
  * @iec: true if IEC prefix should be used, false for SI prefix.
  *
- * Reduces the value to the range 0-1024 or 0-1000, depending on whether
- * the unit is bytes or bits respectively, and selects the appropriate
- * prefix (Ki, M etc.).
+ * Reduces the value to the range 0-1024 or 0-1000, depending on the
+ * iec argument, and selects the appropriate prefix (Ki, M etc.).
  **/
 struct prefixed_value use_prefix(const float value, const bool iec)
 {


### PR DESCRIPTION
I suggest changing the units for transfer speed from bytes per second to bits per second, since network speeds are usually measured in bits per second.

The prefixes have been based on 1024 sizes, which are known as kibi, mebi et.c. The used prefixes have however been the SI ones (kilo, mega et.c.), which are really based on 1000. So I suggest to correct this by using KiB, MiB, GiB, TiB, PiB and EiB for the total number of bytes transferred.

I do however suggest switching to 1000 for the transfer speeds, since they are usually not based on 1024. This then requires the SI prefixes to be kept for the speed values.